### PR TITLE
Switch icons to Tabler

### DIFF
--- a/src/app/applications/[id]/page.tsx
+++ b/src/app/applications/[id]/page.tsx
@@ -51,7 +51,7 @@ import {
   Tag,
   Clock as ClockIcon,
   MessageCircle,
-} from "lucide-react";
+} from "@/lib/tabler-icons";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Progress } from "@/components/ui/progress";
 import { ScrollArea } from "@/components/ui/scroll-area";

--- a/src/app/applications/page.tsx
+++ b/src/app/applications/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { PageLayout } from "@/components/page-layout";
-import { LayoutGrid, Table as TableIcon, Search, Plus } from "lucide-react";
+import { LayoutGrid, Table as TableIcon, Search, Plus } from "@/lib/tabler-icons";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -22,7 +22,7 @@ import {
   History,
   Mail,
   FileText,
-} from "lucide-react";
+} from "@/lib/tabler-icons";
 import { getUserWorkspaceData } from "@/lib/auth/workspace";
 import { formatDistanceToNow } from "date-fns";
 import { nb } from "date-fns/locale";

--- a/src/components/application/application-table.tsx
+++ b/src/components/application/application-table.tsx
@@ -14,7 +14,7 @@ import { Badge } from "@/components/ui/badge";
 import { formatDistanceToNow, format } from "date-fns";
 import { nb } from "date-fns/locale";
 import { Button } from "@/components/ui/button";
-import { Eye, Edit, Trash } from "lucide-react";
+import { Eye, Edit, Trash } from "@/lib/tabler-icons";
 import { updateApplicationStatus } from "@/app/actions/applications/actions";
 import { toast } from "sonner";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/src/components/application/applications-kanban.tsx
+++ b/src/components/application/applications-kanban.tsx
@@ -19,7 +19,7 @@ import {
   Mail,
   Phone,
   Eye,
-} from "lucide-react";
+} from "@/lib/tabler-icons";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/src/components/customer/customer-columns.tsx
+++ b/src/components/customer/customer-columns.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
-import { ArrowUpDown, ExternalLink } from "lucide-react";
+import { ArrowUpDown, ExternalLink } from "@/lib/tabler-icons";
 import { Business, CustomerStage } from "@/app/generated/prisma";
 import Link from "next/link";
 

--- a/src/components/help/help-dialog.tsx
+++ b/src/components/help/help-dialog.tsx
@@ -15,7 +15,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { sendHelpRequest } from "@/app/actions/help/actions";
 import { toast } from "sonner";
-import { Loader2 } from "lucide-react";
+import { Loader2 } from "@/lib/tabler-icons";
 
 interface HelpDialogProps {
   trigger: React.ReactNode; // Accept the trigger element as a prop

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
-import { BookOpen } from "lucide-react";
+import { BookOpen } from "@/lib/tabler-icons";
 import { cn } from "@/lib/utils";
 
 export default function HeroSection() {

--- a/src/components/lead/add-lead-button-wrapper.tsx
+++ b/src/components/lead/add-lead-button-wrapper.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Plus } from "lucide-react";
+import { Plus } from "@/lib/tabler-icons";
 import { AddLeadModal } from "./add-lead-modal"; // Import the modal
 
 interface AddLeadButtonWrapperProps {

--- a/src/components/lead/add-lead-modal.tsx
+++ b/src/components/lead/add-lead-modal.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Loader2 } from "lucide-react";
+import { Loader2 } from "@/lib/tabler-icons";
 import { createLeadFromOrgNumber } from "@/app/actions/leads/actions";
 
 interface AddLeadModalProps {

--- a/src/components/lead/columns.tsx
+++ b/src/components/lead/columns.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
-import { ArrowUpDown, MoreHorizontal } from "lucide-react";
+import { ArrowUpDown, MoreHorizontal } from "@/lib/tabler-icons";
 import { Business, CustomerStage } from "@/app/generated/prisma";
 
 import { Button } from "@/components/ui/button";

--- a/src/components/lead/create-offer.tsx
+++ b/src/components/lead/create-offer.tsx
@@ -13,7 +13,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Plus, Trash2, Send, Mail } from "lucide-react";
+import { Plus, Trash2, Send, Mail } from "@/lib/tabler-icons";
 import { toast } from "sonner";
 import { Business, Offer, OfferItem } from "@/lib/types";
 import {
@@ -36,7 +36,7 @@ import {
   Package,
   PlusCircle,
   SaveIcon,
-} from "lucide-react";
+} from "@/lib/tabler-icons";
 import { Calendar } from "@/components/ui/calendar";
 import { cn } from "@/lib/utils";
 import { format } from "date-fns";

--- a/src/components/lead/data-table.tsx
+++ b/src/components/lead/data-table.tsx
@@ -13,7 +13,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown } from "@/lib/tabler-icons";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/src/components/lead/edit-lead-sheet.tsx
+++ b/src/components/lead/edit-lead-sheet.tsx
@@ -29,7 +29,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { updateLeadDetails } from "@/app/actions/leads/actions"; // Import the updated server action
-import { Loader2 } from "lucide-react"; // For loading indicator
+import { Loader2 } from "@/lib/tabler-icons"; // For loading indicator
 
 // Define the Zod schema for the form, mirroring the server action's schema
 const editLeadFormSchema = z.object({

--- a/src/components/lead/empty-state.tsx
+++ b/src/components/lead/empty-state.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { Plus } from "lucide-react";
+import { Plus } from "@/lib/tabler-icons";
 
 interface EmptyStateProps {
   title?: string;

--- a/src/components/lead/lead-details-tab.tsx
+++ b/src/components/lead/lead-details-tab.tsx
@@ -11,7 +11,7 @@ import {
   Calendar,
   DollarSign,
   FileText,
-} from "lucide-react";
+} from "@/lib/tabler-icons";
 
 interface LeadDetailsTabProps {
   lead: Business;

--- a/src/components/lead/lead-emails.tsx
+++ b/src/components/lead/lead-emails.tsx
@@ -39,7 +39,7 @@ import {
   Paperclip,
   Download,
   X,
-} from "lucide-react";
+} from "@/lib/tabler-icons";
 
 // Import server actions
 import {

--- a/src/components/lead/lead-header.tsx
+++ b/src/components/lead/lead-header.tsx
@@ -25,7 +25,7 @@ import {
   PencilLine,
   MoveUp,
   CheckCircle,
-} from "lucide-react";
+} from "@/lib/tabler-icons";
 import { useState } from "react";
 import { toast } from "sonner";
 

--- a/src/components/lead/lead-info-cards.tsx
+++ b/src/components/lead/lead-info-cards.tsx
@@ -4,7 +4,7 @@ import { Business, CustomerStage } from "@/app/generated/prisma";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Mail, Phone, DollarSign, Calendar, Info } from "lucide-react";
+import { Mail, Phone, DollarSign, Calendar, Info } from "@/lib/tabler-icons";
 
 interface LeadInfoCardsProps {
   lead: Business;

--- a/src/components/lead/lead-notes.tsx
+++ b/src/components/lead/lead-notes.tsx
@@ -13,7 +13,7 @@ import {
   CalendarDays,
   Loader2,
   Pencil,
-} from "lucide-react";
+} from "@/lib/tabler-icons";
 import { Button } from "@/components/ui/button";
 import {
   Card,

--- a/src/components/lead/lead-offers.tsx
+++ b/src/components/lead/lead-offers.tsx
@@ -17,7 +17,7 @@ import {
   ChevronDown,
   Pencil,
   Trash,
-} from "lucide-react";
+} from "@/lib/tabler-icons";
 import { Button } from "@/components/ui/button";
 import {
   Card,

--- a/src/components/lead/lead-proff-info.tsx
+++ b/src/components/lead/lead-proff-info.tsx
@@ -18,7 +18,7 @@ import {
   CircleDollarSign,
   Briefcase,
   BarChart2,
-} from "lucide-react";
+} from "@/lib/tabler-icons";
 import { Button } from "@/components/ui/button";
 import {
   Card,

--- a/src/components/lead/leads-client.tsx
+++ b/src/components/lead/leads-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useTransition } from "react";
-import { LayoutGrid, Table as TableIcon, Search } from "lucide-react";
+import { LayoutGrid, Table as TableIcon, Search } from "@/lib/tabler-icons";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";

--- a/src/components/lead/send-sms-dialog.tsx
+++ b/src/components/lead/send-sms-dialog.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { toast } from "sonner";
 import { Business } from "@/app/generated/prisma";
-import { Send, XIcon } from "lucide-react";
+import { Send, XIcon } from "@/lib/tabler-icons";
 
 import {
   Dialog,

--- a/src/components/sections/pricing.tsx
+++ b/src/components/sections/pricing.tsx
@@ -7,7 +7,7 @@ import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { siteConfig } from "@/lib/config";
 import { cn } from "@/lib/utils";
 import { motion } from "framer-motion";
-import { Check } from "lucide-react";
+import { Check } from "@/lib/tabler-icons";
 import { useState } from "react";
 
 interface TabsProps {

--- a/src/components/sections/use-cases.tsx
+++ b/src/components/sections/use-cases.tsx
@@ -15,7 +15,7 @@ import {
   SquareTerminal,
   UserSearch,
   XCircleIcon,
-} from "lucide-react";
+} from "@/lib/tabler-icons";
 
 const containerVariants = {
   initial: {},

--- a/src/components/team-switcher.tsx
+++ b/src/components/team-switcher.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { ChevronsUpDown, Plus } from "lucide-react"
+import { ChevronsUpDown, Plus } from "@/lib/tabler-icons"
 
 import {
   DropdownMenu,

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Moon, Sun } from "lucide-react";
+import { Moon, Sun } from "@/lib/tabler-icons";
 import { useTheme } from "next-themes";
 
 export function ThemeToggle() {

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as AccordionPrimitive from "@radix-ui/react-accordion"
-import { ChevronDownIcon } from "lucide-react"
+import { ChevronDownIcon } from "@/lib/tabler-icons"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { ChevronRight, MoreHorizontal } from "lucide-react"
+import { ChevronRight, MoreHorizontal } from "@/lib/tabler-icons"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { ChevronLeft, ChevronRight } from "lucide-react"
+import { ChevronLeft, ChevronRight } from "@/lib/tabler-icons"
 import { DayPicker } from "react-day-picker"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import useEmblaCarousel, {
   type UseEmblaCarouselType,
 } from "embla-carousel-react"
-import { ArrowLeft, ArrowRight } from "lucide-react"
+import { ArrowLeft, ArrowRight } from "@/lib/tabler-icons"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
-import { CheckIcon } from "lucide-react"
+import { CheckIcon } from "@/lib/tabler-icons"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { Command as CommandPrimitive } from "cmdk"
-import { SearchIcon } from "lucide-react"
+import { SearchIcon } from "@/lib/tabler-icons"
 
 import { cn } from "@/lib/utils"
 import {

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as ContextMenuPrimitive from "@radix-ui/react-context-menu"
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "@/lib/tabler-icons"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { XIcon } from "lucide-react"
+import { XIcon } from "@/lib/tabler-icons"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "@/lib/tabler-icons"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { OTPInput, OTPInputContext } from "input-otp"
-import { MinusIcon } from "lucide-react"
+import { MinusIcon } from "@/lib/tabler-icons"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as MenubarPrimitive from "@radix-ui/react-menubar"
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "@/lib/tabler-icons"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
 import { cva } from "class-variance-authority"
-import { ChevronDownIcon } from "lucide-react"
+import { ChevronDownIcon } from "@/lib/tabler-icons"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -3,7 +3,7 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   MoreHorizontalIcon,
-} from "lucide-react"
+} from "@/lib/tabler-icons"
 
 import { cn } from "@/lib/utils"
 import { Button, buttonVariants } from "@/components/ui/button"

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
-import { CircleIcon } from "lucide-react"
+import { CircleIcon } from "@/lib/tabler-icons"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { GripVerticalIcon } from "lucide-react"
+import { GripVerticalIcon } from "@/lib/tabler-icons"
 import * as ResizablePrimitive from "react-resizable-panels"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "@/lib/tabler-icons"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
-import { XIcon } from "lucide-react"
+import { XIcon } from "@/lib/tabler-icons"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { VariantProps, cva } from "class-variance-authority";
-import { PanelLeftIcon } from "lucide-react";
+import { PanelLeftIcon } from "@/lib/tabler-icons";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/src/lib/lead-status-utils.tsx
+++ b/src/lib/lead-status-utils.tsx
@@ -5,7 +5,7 @@ import {
   CheckCircle,
   ArrowUpCircle,
   AlertCircle,
-} from "lucide-react";
+} from "@/lib/tabler-icons";
 import React from "react";
 
 export function getStatusBadgeProps(stage: CustomerStage) {

--- a/src/lib/tabler-icons.tsx
+++ b/src/lib/tabler-icons.tsx
@@ -1,0 +1,171 @@
+import {
+  IconActivity,
+  IconAlertCircle,
+  IconAlertTriangle,
+  IconArrowLeft,
+  IconArrowMoveUp,
+  IconArrowRight,
+  IconArrowRightCircle,
+  IconArrowUpCircle,
+  IconArrowUpRight,
+  IconArrowsUpDown,
+  IconBook2,
+  IconBrain,
+  IconBriefcase,
+  IconBuilding,
+  IconCalendar,
+  IconChartBar,
+  IconCheck,
+  IconChevronDown,
+  IconChevronLeft,
+  IconChevronRight,
+  IconChevronUp,
+  IconCircle,
+  IconCircleCheck,
+  IconCirclePlus,
+  IconCircleX,
+  IconClock,
+  IconCurrencyDollar,
+  IconDatabase,
+  IconDeviceFloppy,
+  IconDots,
+  IconDownload,
+  IconEdit,
+  IconExternalLink,
+  IconEye,
+  IconFileText,
+  IconFlame,
+  IconGitFork,
+  IconGlobe,
+  IconGripVertical,
+  IconHeadset,
+  IconHistory,
+  IconInfoCircle,
+  IconLayoutGrid,
+  IconLayoutSidebarLeftExpand,
+  IconLoader2,
+  IconMail,
+  IconMapPin,
+  IconMessage,
+  IconMessageCircle,
+  IconMinus,
+  IconMoon,
+  IconPackage,
+  IconPaperclip,
+  IconPencil,
+  IconPhone,
+  IconPlus,
+  IconRefresh,
+  IconSchool,
+  IconSearch,
+  IconSelector,
+  IconSend,
+  IconStar,
+  IconStarOff,
+  IconSun,
+  IconTable,
+  IconTag,
+  IconTerminal,
+  IconTrash,
+  IconUpload,
+  IconUser,
+  IconUserCheck,
+  IconUserSearch,
+  IconUsers,
+  IconX
+} from "@tabler/icons-react";
+
+export const Activity = IconActivity;
+export const AlertCircle = IconAlertCircle;
+export const AlertTriangleIcon = IconAlertTriangle;
+export const ArrowLeft = IconArrowLeft;
+export const ArrowRight = IconArrowRight;
+export const ArrowRightCircle = IconArrowRightCircle;
+export const ArrowUpCircle = IconArrowUpCircle;
+export const ArrowUpDown = IconArrowsUpDown;
+export const ArrowUpRight = IconArrowUpRight;
+export const BarChart2 = IconChartBar;
+export const BarChart3 = IconChartBar;
+export const BarChart4 = IconChartBar;
+export const BookOpen = IconBook2;
+export const BrainCircuitIcon = IconBrain;
+export const Briefcase = IconBriefcase;
+export const Building = IconBuilding;
+export const Building2 = IconBuilding;
+export const Calendar = IconCalendar;
+export const CalendarDays = IconCalendar;
+export const CalendarIcon = IconCalendar;
+export const CalendarRange = IconCalendar;
+export const Check = IconCheck;
+export const CheckCircle = IconCircleCheck;
+export const CheckIcon = IconCheck;
+export const ChevronDown = IconChevronDown;
+export const ChevronDownIcon = IconChevronDown;
+export const ChevronLeft = IconChevronLeft;
+export const ChevronLeftIcon = IconChevronLeft;
+export const ChevronRight = IconChevronRight;
+export const ChevronRightIcon = IconChevronRight;
+export const ChevronUpIcon = IconChevronUp;
+export const ChevronsUpDown = IconSelector;
+export const CircleDollarSign = IconCurrencyDollar;
+export const CircleIcon = IconCircle;
+export const Clock = IconClock;
+export const DatabaseIcon = IconDatabase;
+export const DollarSign = IconCurrencyDollar;
+export const Download = IconDownload;
+export const Edit = IconEdit;
+export const ExternalLink = IconExternalLink;
+export const Eye = IconEye;
+export const FileText = IconFileText;
+export const Flame = IconFlame;
+export const GitForkIcon = IconGitFork;
+export const Globe = IconGlobe;
+export const GraduationCap = IconSchool;
+export const GripVerticalIcon = IconGripVertical;
+export const HeadsetIcon = IconHeadset;
+export const History = IconHistory;
+export const Info = IconInfoCircle;
+export const InfoIcon = IconInfoCircle;
+export const LayoutGrid = IconLayoutGrid;
+export const Loader2 = IconLoader2;
+export const Mail = IconMail;
+export const MapPin = IconMapPin;
+export const MessageCircle = IconMessageCircle;
+export const MessageSquare = IconMessage;
+export const MessageSquareIcon = IconMessage;
+export const MinusIcon = IconMinus;
+export const Moon = IconMoon;
+export const MoreHorizontal = IconDots;
+export const MoreHorizontalIcon = IconDots;
+export const MoveUp = IconArrowMoveUp;
+export const Package = IconPackage;
+export const PanelLeftIcon = IconLayoutSidebarLeftExpand;
+export const Paperclip = IconPaperclip;
+export const Pencil = IconPencil;
+export const PencilLine = IconPencil;
+export const Phone = IconPhone;
+export const Plus = IconPlus;
+export const PlusCircle = IconCirclePlus;
+export const RefreshCw = IconRefresh;
+export const Save = IconDeviceFloppy;
+export const SaveIcon = IconDeviceFloppy;
+export const Search = IconSearch;
+export const SearchIcon = IconSearch;
+export const Send = IconSend;
+export const SquareTerminal = IconTerminal;
+export const Star = IconStar;
+export const StarOff = IconStarOff;
+export const Sun = IconSun;
+export const Table = IconTable;
+export const Tag = IconTag;
+export const Trash = IconTrash;
+export const Trash2 = IconTrash;
+export const Upload = IconUpload;
+export const User = IconUser;
+export const UserCheck = IconUserCheck;
+export const UserSearch = IconUserSearch;
+export const Users = IconUsers;
+export const X = IconX;
+export const XCircle = IconCircleX;
+export const XCircleIcon = IconCircleX;
+export const XIcon = IconX;


### PR DESCRIPTION
## Summary
- remove lucide-react dependency
- create `tabler-icons` wrapper exporting tabler components under old names
- update all icon imports to use the wrapper
- add lucide-react back to `package.json`
