### PR TITLE
Implement workspace invitations

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -322,6 +322,24 @@ enum TaskPriority {
   @@map("task_priority")
 }
 
+// Invitation for users to join a workspace
+model WorkspaceInvitation {
+  id          String   @id @default(cuid())
+  email       String
+  token       String   @unique
+  createdAt   DateTime @default(now())
+  expiresAt   DateTime
+  acceptedAt  DateTime?
+
+  // Relations
+  workspaceId String
+  workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  inviterId   String?
+  inviter     User?     @relation(fields: [inviterId], references: [id], onDelete: SetNull)
+
+  @@map("workspace_invitations")
+}
+
 // Workspace model - Represents a tenant or organization space
 model Workspace {
   id        String   @id @default(cuid())

--- a/src/app/accept-invite/page.tsx
+++ b/src/app/accept-invite/page.tsx
@@ -1,0 +1,15 @@
+import { acceptWorkspaceInvitation } from "@/app/actions/workspace/actions";
+import { redirect } from "next/navigation";
+
+interface AcceptInvitePageProps {
+  searchParams: { token?: string };
+}
+
+export default async function AcceptInvitePage({ searchParams }: AcceptInvitePageProps) {
+  const token = searchParams.token;
+  if (!token) {
+    redirect("/");
+  }
+  await acceptWorkspaceInvitation(token as string);
+  redirect("/");
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/app/actions/settings/actions"; // Import admin check
 import { redirect } from "next/navigation";
 import { WorkspaceForm } from "@/components/settings/workspace-form"; // Import WorkspaceForm
+import { InviteForm } from "@/components/settings/invite-form";
 import { prisma } from "@/lib/db"; // Import prisma for fetching workspace details
 
 export const metadata: Metadata = {
@@ -91,6 +92,7 @@ export default async function SettingsPage() {
           <TabsContent value="workspace" className="space-y-4">
             {/* Integrate the WorkspaceForm */}
             <WorkspaceForm workspace={workspaceData} />
+            <InviteForm workspaceId={workspaceData.id} />
             {/* Other workspace settings components will go here later */}
           </TabsContent>
         )}

--- a/src/components/settings/invite-form.tsx
+++ b/src/components/settings/invite-form.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { inviteToWorkspace } from "@/app/actions/workspace/actions";
+import { toast } from "sonner";
+import { useTransition, useState } from "react";
+
+const inviteFormSchema = z.object({
+  email: z.string().email("Ugyldig e-post"),
+});
+
+type InviteFormValues = z.infer<typeof inviteFormSchema>;
+
+interface InviteFormProps {
+  workspaceId: string;
+}
+
+export function InviteForm({ workspaceId }: InviteFormProps) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const form = useForm<InviteFormValues>({
+    resolver: zodResolver(inviteFormSchema),
+    defaultValues: { email: "" },
+    mode: "onChange",
+  });
+
+  async function onSubmit(data: InviteFormValues) {
+    setError(null);
+    startTransition(async () => {
+      const formData = new FormData();
+      formData.append("workspaceId", workspaceId);
+      formData.append("email", data.email);
+      try {
+        const result = await inviteToWorkspace(formData);
+        if (result.success) {
+          toast.success("Invitasjon sendt!");
+          form.reset();
+        } else {
+          setError(result.message || "Kunne ikke sende invitasjon");
+          toast.error(result.message || "Kunne ikke sende invitasjon");
+        }
+      } catch (e) {
+        const errorMsg = e instanceof Error ? e.message : "En ukjent feil oppstod";
+        setError(errorMsg);
+        toast.error(errorMsg);
+      }
+    });
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Inviter bruker</CardTitle>
+        <CardDescription>Send en e-postinvitasjon til arbeidsområdet.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>E-post</FormLabel>
+                  <FormControl>
+                    <Input placeholder="bruker@example.com" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {error && (
+              <p className="text-sm font-medium text-destructive">{error}</p>
+            )}
+            <Button type="submit" disabled={isPending || !form.formState.isDirty}>
+              {isPending ? "Sender..." : "Send invitasjon"}
+            </Button>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- support workspace invitations in Prisma schema
- add server actions to invite and accept workspace membership
- add InviteForm component and integrate into settings
- create page to handle invite acceptance

## Testing
- `pnpm install` *(fails: fetch binaries from `binaries.prisma.sh` blocked)*
- `pnpm lint` *(fails: interactive configuration required)*


------
https://chatgpt.com/codex/tasks/task_e_68594d9cfa608330b74894d5b737e68a